### PR TITLE
Update complex-scheme.sh memory parameters

### DIFF
--- a/scripts/complex-scheme.sh
+++ b/scripts/complex-scheme.sh
@@ -17,12 +17,12 @@ FIRST_PREIMAGE_NBITS=63
 # if OPS=10 takes 60s, then for N days:
 # N * 24 * 3600 / 60 * 10 = N * 14400
 MONTHS_LONG_OPS=$((DAYS * 14400))
-# This is 16GB
-LARGE_MEM_LIMIT_KBYTES=16777216
+# This is 8GiB
+LARGE_MEM_LIMIT_KBYTES=8388608
 
 # The second preimage is easy to derive but requires money/time to brute-force
 SECONDS_LONG_OPS=7
-# This is 4GB
+# This is 4GiB
 SMALL_MEM_LIMIT_KBYTES=4194304
 
 if [[ ! -f "$SALT" ]]; then


### PR DESCRIPTION
## Summary
- Reduce first layer memory requirement from 16GiB to 8GiB for better accessibility
- Fix unit notation in comments (GB → GiB) to be technically accurate

## Changes
- `LARGE_MEM_LIMIT_KBYTES`: 16777216 → 8388608 (16GiB → 8GiB)
- Updated comments to use GiB instead of GB since values are in kibibytes (1024-based)

## Rationale
- 8GiB is still a substantial memory requirement that provides good security
- More accessible for users who want to test the complex scheme
- Maintains the security properties while being more practical