### PR TITLE
Fix ops calculation for 30-second derivation time

### DIFF
--- a/scripts/complex-scheme.sh
+++ b/scripts/complex-scheme.sh
@@ -14,9 +14,9 @@ KEYFILE_SIZE="32"
 # There is no good reason to use a low value here
 FIRST_PREIMAGE_NBITS=63
 # Calculate ops based on input days parameter
-# if OPS=10 takes 60s, then for N days:
-# N * 24 * 3600 / 60 * 10 = N * 14400
-MONTHS_LONG_OPS=$((DAYS * 14400))
+# if OPS=10 takes 30s, then for N days:
+# N * 24 * 3600 / 30 * 10 = N * 28800
+MONTHS_LONG_OPS=$((DAYS * 28800))
 # This is 8GiB
 LARGE_MEM_LIMIT_KBYTES=8388608
 


### PR DESCRIPTION
## Summary
Fix the ops calculation in complex-scheme.sh to correctly reflect the baseline derivation time.

## Changes
- Updated comment: OPS=10 takes 30s (not 60s)
- Fixed calculation: N days = N * 28800 ops (was N * 14400)

## Details
The previous calculation assumed OPS=10 takes 60 seconds, but the actual baseline is 30 seconds. This meant the time-lock was only half as long as intended. With this fix, the calculation now correctly produces the intended time-lock duration.

## Testing
The formula can be verified:
- 1 day = 24 hours × 3600 seconds = 86,400 seconds
- With OPS=10 taking 30 seconds: 86,400 / 30 × 10 = 28,800 ops per day