### PR TITLE
Add security workflow and Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,40 @@
+version: 2
+
+updates:
+  # Cargo dependencies
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "douglaz"
+    assignees:
+      - "douglaz"
+    commit-message:
+      prefix: "cargo"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "rust"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+    open-pull-requests-limit: 5
+    reviewers:
+      - "douglaz"
+    assignees:
+      - "douglaz"
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,75 @@
+name: Security
+
+on:
+  push:
+    branches: [ main, master, develop ]
+  pull_request:
+    branches: [ main, master, develop ]
+  schedule:
+    # Run security audit weekly on Sundays at 6 AM UTC
+    - cron: '0 6 * * 0'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  security-audit:
+    name: Security Audit
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v5
+
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
+
+    - name: Cache cargo dependencies
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+        key: audit-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+
+    - name: Install cargo-audit
+      run: cargo install cargo-audit
+
+    - name: Run cargo audit
+      run: cargo audit
+
+    - name: Run cargo audit (JSON output)
+      run: cargo audit --json > audit-results.json
+      continue-on-error: true
+
+    - name: Upload audit results
+      uses: actions/upload-artifact@v4
+      with:
+        name: security-audit-results
+        path: audit-results.json
+        retention-days: 30
+
+  supply-chain-security:
+    name: Supply Chain Security
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v5
+
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
+
+    - name: Cache cargo dependencies
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+        key: supply-chain-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+
+    - name: Install cargo-deny
+      run: cargo install cargo-deny
+
+    - name: Run cargo deny
+      run: cargo deny check


### PR DESCRIPTION
## Summary
- Add comprehensive security scanning workflow
- Configure Dependabot for automated dependency updates

## Changes
- **Security Workflow** (`.github/workflows/security.yml`):
  - `cargo-audit`: Scans for known security vulnerabilities in dependencies
  - `cargo-deny`: Performs supply chain security checks for licenses and banned dependencies
  - Runs on push, pull requests, and weekly schedule (Sundays at 6 AM UTC)
  - Generates and stores audit reports as artifacts

- **Dependabot Configuration** (`.github/dependabot.yml`):
  - Monitors Cargo dependencies for updates
  - Monitors GitHub Actions for updates
  - Weekly update schedule (Mondays at 6 AM UTC)
  - Automatic PR creation with proper labeling and commit prefixes

## Benefits
- Proactive security vulnerability detection
- Automated dependency management
- Supply chain security validation
- Consistent security scanning schedule

## Test Plan
- [x] Workflow syntax validated
- [ ] Security workflow will run on merge
- [ ] Dependabot will create PRs starting next Monday