### PR TITLE
Fix cargo-deny configuration and add license information

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,43 @@
+# cargo-deny configuration
+
+[advisories]
+# The advisories section is used to detect crates with security vulnerabilities
+db-path = "~/.cargo/advisory-db"
+db-urls = ["https://github.com/rustsec/advisory-db"]
+yanked = "warn"
+
+[licenses]
+# List of explicitly allowed licenses
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "Unicode-3.0",
+    "Unlicense",
+]
+
+# The confidence threshold for detecting a license from license text
+confidence-threshold = 0.8
+
+[bans]
+# Lint level for when multiple versions of the same crate are detected
+multiple-versions = "warn"
+wildcards = "allow"
+highlight = "all"
+
+# List of explicitly disallowed crates
+deny = []
+
+# Skip certain crates when checking for duplicates
+skip = []
+
+# Similarly named crates that are allowed to coexist
+skip-tree = []
+
+[sources]
+# Lint level for what to happen when a crate from a crate registry that is not in the allow list is encountered
+unknown-registry = "warn"
+unknown-git = "warn"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []

--- a/wskdf-cli/Cargo.toml
+++ b/wskdf-cli/Cargo.toml
@@ -2,6 +2,7 @@
 name = "wskdf-cli"
 version = "0.1.0"
 edition = "2024"
+license = "MIT OR Apache-2.0"
 
 
 [dependencies]

--- a/wskdf-core/Cargo.toml
+++ b/wskdf-core/Cargo.toml
@@ -2,6 +2,7 @@
 name = "wskdf-core"
 version = "0.1.0"
 edition = "2024"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 alkali = { version = "0.3", optional = true }


### PR DESCRIPTION
## Summary
Fixes the failing security workflow by adding proper cargo-deny configuration and license information to the workspace crates.

## Problem
The security workflow was failing because:
1. cargo-deny requires a configuration file to specify allowed licenses
2. The workspace crates (wskdf-core and wskdf-cli) were missing license declarations
3. The Unicode-3.0 license (used by unicode-ident dependency) wasn't in the allowed list

## Solution
- Added `deny.toml` configuration file with proper license allowlist
- Added `license = "MIT OR Apache-2.0"` to both workspace Cargo.toml files
- Included all necessary licenses in the allowlist (MIT, Apache-2.0, Unicode-3.0, etc.)

## Changes
- **deny.toml**: New cargo-deny configuration file
- **wskdf-core/Cargo.toml**: Added license field
- **wskdf-cli/Cargo.toml**: Added license field

## Test Plan
- [x] `cargo deny check` passes locally
- [ ] Security workflow will pass on merge
- [ ] No impact on functionality (metadata changes only)

## Related
- Fixes the security workflow failure in PR #7