### PR TITLE
fix(scripts): check for gpg before expensive key derivation

### DIFF
--- a/scripts/complex-scheme.sh
+++ b/scripts/complex-scheme.sh
@@ -25,6 +25,11 @@ SECONDS_LONG_OPS=7
 # This is 4GiB
 SMALL_MEM_LIMIT_KBYTES=4194304
 
+if ! command -v gpg &>/dev/null; then
+    echo "gpg is required but not found"
+    exit 1
+fi
+
 if [[ ! -f "$SALT" ]]; then
     echo "Salt file not found"
     exit 1


### PR DESCRIPTION
## Summary
- Add early `gpg` availability check in `complex-scheme.sh` before starting any key derivation
- Prevents wasting a multi-day computation that would fail at the encryption step anyway

## Test plan
- [ ] Run `complex-scheme.sh` without `gpg` installed — should fail immediately with a clear message
- [ ] Run `complex-scheme.sh` with `gpg` installed — should proceed as before