### PR TITLE
ci: add dependency grouping to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,17 @@ updates:
     labels:
       - "dependencies"
       - "rust"
+    groups:
+      patch-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+      minor-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
 
   # GitHub Actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## Summary
- Add dependency grouping (patch/minor) to existing Dependabot config
- Reduces PR noise by batching similar version bumps

## Context
Standardizing Dependabot configuration across all Rust repositories.