### PR TITLE
ci: remove Magic Nix Cache from workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,6 @@ jobs:
     - name: Install Nix
       uses: DeterminateSystems/nix-installer-action@main
       
-    - name: Setup Nix Cache
-      uses: DeterminateSystems/magic-nix-cache-action@main
-      
     - name: Build project
       run: nix develop --command cargo build -F alkali --release
       


### PR DESCRIPTION
Removes the `DeterminateSystems/magic-nix-cache-action` step — it has been unreliable in CI (rate-limited local substituter). Nix now fetches from `cache.nixos.org` directly; the Nix installer and Cargo registry cache are unchanged.